### PR TITLE
Dynamic context

### DIFF
--- a/src/common/rohc_list.c
+++ b/src/common/rohc_list.c
@@ -198,7 +198,8 @@ static bool rohc_list_item_update(struct rohc_list_item *const list_item,
 	{
 		return false;
 	}
-	if(list_item->data == NULL) {
+	if(list_item->data == NULL)
+	{
 		list_item->data = malloc(ROHC_LIST_ITEM_DATA_MAX*sizeof(uint8_t));
 	}
 	memcpy(list_item->data, item_data, item_len);

--- a/src/common/rohc_list.c
+++ b/src/common/rohc_list.c
@@ -198,9 +198,9 @@ static bool rohc_list_item_update(struct rohc_list_item *const list_item,
 	{
 		return false;
 	}
-    if(list_item->data == NULL) {
-        list_item->data = malloc(ROHC_LIST_ITEM_DATA_MAX*sizeof(uint8_t));
-    }
+	if(list_item->data == NULL) {
+		list_item->data = malloc(ROHC_LIST_ITEM_DATA_MAX*sizeof(uint8_t));
+	}
 	memcpy(list_item->data, item_data, item_len);
 	list_item->length = item_len;
 	list_item->type = item_type;

--- a/src/common/rohc_list.c
+++ b/src/common/rohc_list.c
@@ -198,10 +198,12 @@ static bool rohc_list_item_update(struct rohc_list_item *const list_item,
 	{
 		return false;
 	}
+    if(list_item->data == NULL) {
+        list_item->data = malloc(ROHC_LIST_ITEM_DATA_MAX*sizeof(uint8_t));
+    }
 	memcpy(list_item->data, item_data, item_len);
 	list_item->length = item_len;
 	list_item->type = item_type;
 
 	return true;
 }
-

--- a/src/common/rohc_list.h
+++ b/src/common/rohc_list.h
@@ -98,7 +98,7 @@ struct rohc_list_item
 	/** The length of the item data (in bytes) */
 	size_t length;
 	/** The item data */
-	uint8_t data[ROHC_LIST_ITEM_DATA_MAX];
+	uint8_t *data;
 };
 
 
@@ -137,4 +137,3 @@ int rohc_list_item_update_if_changed(rohc_list_item_cmp cmp_item,
 	__attribute__((warn_unused_result, nonnull(2, 4)));
 
 #endif
-

--- a/src/comp/c_tcp.c
+++ b/src/comp/c_tcp.c
@@ -888,7 +888,8 @@ static bool c_tcp_create(struct rohc_comp_ctxt *const context,
 
 				assert(remain_len >= sizeof(struct ipv4_hdr));
 				proto = ipv4->protocol;
-				if(rohc_is_tunneling(proto) && tcp_context->ip_contexts_nr < ROHC_TCP_MAX_IP_HDRS-1) {
+				if(rohc_is_tunneling(proto) && tcp_context->ip_contexts_nr < ROHC_TCP_MAX_IP_HDRS-1)
+				{
 					tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1] = malloc(sizeof(ip_context_t));
 					tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1]->opts = NULL;
 				}

--- a/src/comp/c_tcp.c
+++ b/src/comp/c_tcp.c
@@ -272,7 +272,7 @@ typedef struct
 	} ctxt;
 
 	size_t opts_nr;
-	ip_option_context_t opts[ROHC_TCP_MAX_IP_EXT_HDRS];
+	ip_option_context_t *opts;
 
 } ip_context_t;
 
@@ -336,7 +336,7 @@ struct sc_tcp_context
 	struct tcp_tmp_variables tmp;
 
 	size_t ip_contexts_nr;
-	ip_context_t ip_contexts[ROHC_TCP_MAX_IP_HDRS];
+	ip_context_t *ip_contexts[ROHC_TCP_MAX_IP_HDRS];
 };
 
 
@@ -834,8 +834,45 @@ static bool c_tcp_create(struct rohc_comp_ctxt *const context,
 	do
 	{
 		const struct ip_hdr *const ip = (struct ip_hdr *) remain_data;
+        if(tcp_context->ip_contexts_nr == 0) 
+        {
+            switch(ip->version)
+    		{
+                case IPV4:
+    			{
+                    tcp_context->ip_contexts[0] = malloc(sizeof(ip_context_t));
+                    if(tcp_context->ip_contexts[0] == NULL) 
+                    {
+                        goto free_context;
+                    }
+                    tcp_context->ip_contexts[0]->opts = NULL;
+                    for(unsigned int i = 1; i < ROHC_TCP_MAX_IP_HDRS; i++)
+                    {
+                        tcp_context->ip_contexts[i] = NULL;
+                    }
+                }
+                break;
+                case IPV6:
+                {
+                    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++)
+                    {
+                        tcp_context->ip_contexts[i] = malloc(sizeof(ip_context_t));
+                        if(tcp_context->ip_contexts[i] == NULL)
+                        {
+                            goto free_context;
+                        }
+                        tcp_context->ip_contexts[i]->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+                    }
+                }
+                break;
+                default:
+                {
+    				goto free_context;
+    			}
+            }
+        }
 		ip_context_t *const ip_context =
-			&(tcp_context->ip_contexts[tcp_context->ip_contexts_nr]);
+			tcp_context->ip_contexts[tcp_context->ip_contexts_nr];
 
 		/* retrieve IP version */
 		assert(remain_len >= sizeof(struct ip_hdr));
@@ -851,6 +888,10 @@ static bool c_tcp_create(struct rohc_comp_ctxt *const context,
 
 				assert(remain_len >= sizeof(struct ipv4_hdr));
 				proto = ipv4->protocol;
+                if(rohc_is_tunneling(proto) && tcp_context->ip_contexts_nr < ROHC_TCP_MAX_IP_HDRS-1) {
+                    tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1] = malloc(sizeof(ip_context_t));
+                    tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1]->opts = NULL;
+                }
 
 				ip_context->ctxt.v4.last_ip_id = rohc_ntoh16(ipv4->id);
 				rohc_comp_debug(context, "IP-ID 0x%04x", ip_context->ctxt.v4.last_ip_id);
@@ -1072,6 +1113,19 @@ free_wlsb_ip_id:
 free_wlsb_msn:
 	c_destroy_wlsb(tcp_context->msn_wlsb);
 free_context:
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        if(tcp_context->ip_contexts[i] != NULL) 
+        {
+            if(tcp_context->ip_contexts[i]->opts != NULL) 
+            {
+                free(tcp_context->ip_contexts[i]->opts);
+                tcp_context->ip_contexts[i]->opts = NULL;
+            }
+            free(tcp_context->ip_contexts[i]);
+            tcp_context->ip_contexts[i] = NULL;
+        }
+    }
 	free(tcp_context);
 error:
 	return false;
@@ -1097,6 +1151,19 @@ static void c_tcp_destroy(struct rohc_comp_ctxt *const context)
 	c_destroy_wlsb(tcp_context->ip_id_wlsb);
 	c_destroy_wlsb(tcp_context->ttl_hopl_wlsb);
 	c_destroy_wlsb(tcp_context->msn_wlsb);
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        if(tcp_context->ip_contexts[i] != NULL) 
+        {
+            if(tcp_context->ip_contexts[i]->opts != NULL) 
+            {
+                free(tcp_context->ip_contexts[i]->opts);
+                tcp_context->ip_contexts[i]->opts = NULL;
+            }
+            free(tcp_context->ip_contexts[i]);
+            tcp_context->ip_contexts[i] = NULL;
+        }
+    }
 	free(tcp_context);
 }
 
@@ -1521,7 +1588,7 @@ static bool c_tcp_check_context(const struct rohc_comp_ctxt *const context,
 	    ip_hdr_pos++)
 	{
 		const struct ip_hdr *const ip = (struct ip_hdr *) remain_data;
-		const ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_pos]);
+		const ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_pos];
 		size_t ip_ext_pos;
 
 		/* retrieve IP version */
@@ -1758,10 +1825,10 @@ static int c_tcp_encode(struct rohc_comp_ctxt *const context,
 		{
 			rohc_comp_debug(context, "  update context of IP header #%zu:",
 			                ip_hdr_pos + 1);
-			tcp_context->ip_contexts[ip_hdr_pos].opts_nr =
+			tcp_context->ip_contexts[ip_hdr_pos]->opts_nr =
 				tcp_context->tmp.ip_exts_nr[ip_hdr_pos];
 			rohc_comp_debug(context, "    %zu extension headers",
-			                tcp_context->ip_contexts[ip_hdr_pos].opts_nr);
+			                tcp_context->ip_contexts[ip_hdr_pos]->opts_nr);
 		}
 	}
 
@@ -2109,7 +2176,7 @@ static int tcp_code_dyn_part(struct rohc_comp_ctxt *const context,
 	for(ip_hdr_pos = 0; ip_hdr_pos < tcp_context->ip_contexts_nr; ip_hdr_pos++)
 	{
 		const struct ip_hdr *const ip_hdr = (struct ip_hdr *) remain_data;
-		ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_pos]);
+		ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_pos];
 		const bool is_inner = !!(ip_hdr_pos + 1 == tcp_context->ip_contexts_nr);
 		size_t ip_ext_pos;
 
@@ -2732,7 +2799,7 @@ static int tcp_code_irreg_chain(struct rohc_comp_ctxt *const context,
 	for(ip_hdr_pos = 0; ip_hdr_pos < tcp_context->ip_contexts_nr; ip_hdr_pos++)
 	{
 		const struct ip_hdr *const ip_hdr = (struct ip_hdr *) remain_data;
-		ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_pos]);
+		ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_pos];
 		const bool is_innermost = !!(ip_hdr_pos == (tcp_context->ip_contexts_nr - 1));
 
 		/* retrieve IP version */
@@ -3439,7 +3506,7 @@ static int code_CO_packet(struct rohc_comp_ctxt *const context,
 	for(ip_hdr_pos = 0; ip_hdr_pos < tcp_context->ip_contexts_nr; ip_hdr_pos++)
 	{
 		const struct ip_hdr *const ip_hdr = (struct ip_hdr *) remain_data;
-		ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_pos]);
+		ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_pos];
 		uint8_t protocol;
 
 		/* retrieve IP version */
@@ -5141,7 +5208,7 @@ static bool tcp_detect_changes(struct rohc_comp_ctxt *const context,
 	do
 	{
 		const struct ip_hdr *const ip = (struct ip_hdr *) remain_data;
-		ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdrs_nr]);
+		ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdrs_nr];
 
 		assert(remain_len >= sizeof(struct ip_hdr));
 		rohc_comp_debug(context, "found IPv%d header #%zu",
@@ -5623,7 +5690,7 @@ static bool tcp_encode_uncomp_ip_fields(struct rohc_comp_ctxt *const context,
 	for(ip_hdr_pos = 0; ip_hdr_pos < tcp_context->ip_contexts_nr; ip_hdr_pos++)
 	{
 		const struct ip_hdr *const ip = (struct ip_hdr *) remain_data;
-		const ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_pos]);
+		const ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_pos];
 		const bool is_innermost = !!(ip_hdr_pos + 1 == tcp_context->ip_contexts_nr);
 		uint8_t ttl_hopl;
 		size_t ip_ext_pos;
@@ -7281,4 +7348,3 @@ const struct rohc_comp_profile c_tcp_profile =
 	.reinit_context = rohc_comp_reinit_context,
 	.feedback       = c_tcp_feedback,
 };
-

--- a/src/comp/c_tcp.c
+++ b/src/comp/c_tcp.c
@@ -834,43 +834,43 @@ static bool c_tcp_create(struct rohc_comp_ctxt *const context,
 	do
 	{
 		const struct ip_hdr *const ip = (struct ip_hdr *) remain_data;
-        if(tcp_context->ip_contexts_nr == 0) 
-        {
-            switch(ip->version)
-    		{
-                case IPV4:
-    			{
-                    tcp_context->ip_contexts[0] = malloc(sizeof(ip_context_t));
-                    if(tcp_context->ip_contexts[0] == NULL) 
-                    {
-                        goto free_context;
-                    }
-                    tcp_context->ip_contexts[0]->opts = NULL;
-                    for(unsigned int i = 1; i < ROHC_TCP_MAX_IP_HDRS; i++)
-                    {
-                        tcp_context->ip_contexts[i] = NULL;
-                    }
-                }
-                break;
-                case IPV6:
-                {
-                    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++)
-                    {
-                        tcp_context->ip_contexts[i] = malloc(sizeof(ip_context_t));
-                        if(tcp_context->ip_contexts[i] == NULL)
-                        {
-                            goto free_context;
-                        }
-                        tcp_context->ip_contexts[i]->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
-                    }
-                }
-                break;
-                default:
-                {
-    				goto free_context;
-    			}
-            }
-        }
+		if(tcp_context->ip_contexts_nr == 0) 
+		{
+			switch(ip->version)
+			{
+				case IPV4:
+				{
+					tcp_context->ip_contexts[0] = malloc(sizeof(ip_context_t));
+					if(tcp_context->ip_contexts[0] == NULL) 
+					{
+						goto free_context;
+					}
+					tcp_context->ip_contexts[0]->opts = NULL;
+					for(unsigned int i = 1; i < ROHC_TCP_MAX_IP_HDRS; i++)
+					{
+						tcp_context->ip_contexts[i] = NULL;
+					}
+				}
+				break;
+				case IPV6:
+				{
+					for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++)
+					{
+						tcp_context->ip_contexts[i] = malloc(sizeof(ip_context_t));
+						if(tcp_context->ip_contexts[i] == NULL)
+						{
+							goto free_context;
+						}
+						tcp_context->ip_contexts[i]->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+					}
+				}
+				break;
+				default:
+				{
+					goto free_context;
+				}
+			}
+		}
 		ip_context_t *const ip_context =
 			tcp_context->ip_contexts[tcp_context->ip_contexts_nr];
 
@@ -888,10 +888,10 @@ static bool c_tcp_create(struct rohc_comp_ctxt *const context,
 
 				assert(remain_len >= sizeof(struct ipv4_hdr));
 				proto = ipv4->protocol;
-                if(rohc_is_tunneling(proto) && tcp_context->ip_contexts_nr < ROHC_TCP_MAX_IP_HDRS-1) {
-                    tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1] = malloc(sizeof(ip_context_t));
-                    tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1]->opts = NULL;
-                }
+				if(rohc_is_tunneling(proto) && tcp_context->ip_contexts_nr < ROHC_TCP_MAX_IP_HDRS-1) {
+					tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1] = malloc(sizeof(ip_context_t));
+					tcp_context->ip_contexts[tcp_context->ip_contexts_nr+1]->opts = NULL;
+				}
 
 				ip_context->ctxt.v4.last_ip_id = rohc_ntoh16(ipv4->id);
 				rohc_comp_debug(context, "IP-ID 0x%04x", ip_context->ctxt.v4.last_ip_id);
@@ -1113,19 +1113,19 @@ free_wlsb_ip_id:
 free_wlsb_msn:
 	c_destroy_wlsb(tcp_context->msn_wlsb);
 free_context:
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        if(tcp_context->ip_contexts[i] != NULL) 
-        {
-            if(tcp_context->ip_contexts[i]->opts != NULL) 
-            {
-                free(tcp_context->ip_contexts[i]->opts);
-                tcp_context->ip_contexts[i]->opts = NULL;
-            }
-            free(tcp_context->ip_contexts[i]);
-            tcp_context->ip_contexts[i] = NULL;
-        }
-    }
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		if(tcp_context->ip_contexts[i] != NULL) 
+		{
+			if(tcp_context->ip_contexts[i]->opts != NULL) 
+			{
+				free(tcp_context->ip_contexts[i]->opts);
+				tcp_context->ip_contexts[i]->opts = NULL;
+			}
+			free(tcp_context->ip_contexts[i]);
+			tcp_context->ip_contexts[i] = NULL;
+		}
+	}
 	free(tcp_context);
 error:
 	return false;
@@ -1151,19 +1151,19 @@ static void c_tcp_destroy(struct rohc_comp_ctxt *const context)
 	c_destroy_wlsb(tcp_context->ip_id_wlsb);
 	c_destroy_wlsb(tcp_context->ttl_hopl_wlsb);
 	c_destroy_wlsb(tcp_context->msn_wlsb);
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        if(tcp_context->ip_contexts[i] != NULL) 
-        {
-            if(tcp_context->ip_contexts[i]->opts != NULL) 
-            {
-                free(tcp_context->ip_contexts[i]->opts);
-                tcp_context->ip_contexts[i]->opts = NULL;
-            }
-            free(tcp_context->ip_contexts[i]);
-            tcp_context->ip_contexts[i] = NULL;
-        }
-    }
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		if(tcp_context->ip_contexts[i] != NULL) 
+		{
+			if(tcp_context->ip_contexts[i]->opts != NULL) 
+			{
+				free(tcp_context->ip_contexts[i]->opts);
+				tcp_context->ip_contexts[i]->opts = NULL;
+			}
+			free(tcp_context->ip_contexts[i]);
+			tcp_context->ip_contexts[i] = NULL;
+		}
+	}
 	free(tcp_context);
 }
 

--- a/src/comp/rohc_comp_rfc3095.c
+++ b/src/comp/rohc_comp_rfc3095.c
@@ -499,7 +499,8 @@ static void ip_header_info_free(struct ip_header_info *const header_info)
 	else
 	{
 		/* IPv6: destroy the list of IPv6 extension headers */
-		if(header_info->info.v6.ext_comp) {
+		if(header_info->info.v6.ext_comp)
+		{
 			rohc_comp_list_ipv6_free(header_info->info.v6.ext_comp);
 			free(header_info->info.v6.ext_comp);
 			header_info->info.v6.ext_comp = NULL;

--- a/src/comp/rohc_comp_rfc3095.c
+++ b/src/comp/rohc_comp_rfc3095.c
@@ -472,7 +472,7 @@ static bool ip_header_info_new(struct ip_header_info *const header_info,
 	else
 	{
 		/* init the compression context for IPv6 extension header list */
-        header_info->info.v6.ext_comp = malloc(sizeof(struct list_comp));
+		header_info->info.v6.ext_comp = malloc(sizeof(struct list_comp));
 		rohc_comp_list_ipv6_new(header_info->info.v6.ext_comp, list_trans_nr,
 		                        trace_cb, trace_cb_priv, profile_id);
 	}
@@ -499,11 +499,11 @@ static void ip_header_info_free(struct ip_header_info *const header_info)
 	else
 	{
 		/* IPv6: destroy the list of IPv6 extension headers */
-        if(header_info->info.v6.ext_comp) {
-            rohc_comp_list_ipv6_free(header_info->info.v6.ext_comp);
-            free(header_info->info.v6.ext_comp);
-            header_info->info.v6.ext_comp = NULL;
-        }
+		if(header_info->info.v6.ext_comp) {
+			rohc_comp_list_ipv6_free(header_info->info.v6.ext_comp);
+			free(header_info->info.v6.ext_comp);
+			header_info->info.v6.ext_comp = NULL;
+		}
 	}
 }
 

--- a/src/comp/rohc_comp_rfc3095.h
+++ b/src/comp/rohc_comp_rfc3095.h
@@ -103,7 +103,7 @@ struct ipv6_header_info
 	/// The previous IPv6 header
 	struct ipv6_hdr old_ip;
 	/// The extension compressor
-	struct list_comp ext_comp;
+	struct list_comp *ext_comp;
 };
 
 
@@ -466,4 +466,3 @@ static inline size_t get_nr_ipv4_non_rnd_with_bits(const struct rohc_comp_rfc309
 
 
 #endif
-

--- a/src/decomp/d_tcp.c
+++ b/src/decomp/d_tcp.c
@@ -502,13 +502,13 @@ static bool d_tcp_create(const struct rohc_decomp_ctxt *const context,
 		                 "of one of the TCP decompression context");
 		goto free_extr_bits;
 	}
-    
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        tcp_context->ip_contexts[i] = NULL;
-        ((struct rohc_tcp_extr_bits*)(volat_ctxt->extr_bits))->ip[i].opts = NULL;
-        ((struct rohc_tcp_decoded_values*)(volat_ctxt->decoded_values))->ip[i].opts = NULL;
-    }
+	
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		tcp_context->ip_contexts[i] = NULL;
+		((struct rohc_tcp_extr_bits*)(volat_ctxt->extr_bits))->ip[i].opts = NULL;
+		((struct rohc_tcp_decoded_values*)(volat_ctxt->decoded_values))->ip[i].opts = NULL;
+	}
 
 	return true;
 
@@ -577,37 +577,37 @@ static void d_tcp_destroy(struct d_tcp_context *const tcp_context,
 	rohc_lsb_free(tcp_context->msn_lsb_ctxt);
 
 	/* free the TCP decompression context itself */
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        if(tcp_context->ip_contexts[i] != NULL) 
-        {
-            if(tcp_context->ip_contexts[i]->opts != NULL) 
-            {
-                free(tcp_context->ip_contexts[i]->opts);
-                tcp_context->ip_contexts[i]->opts = NULL;
-            }
-            free(tcp_context->ip_contexts[i]);
-            tcp_context->ip_contexts[i] = NULL;
-        }
-    }
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		if(tcp_context->ip_contexts[i] != NULL) 
+		{
+			if(tcp_context->ip_contexts[i]->opts != NULL) 
+			{
+				free(tcp_context->ip_contexts[i]->opts);
+				tcp_context->ip_contexts[i]->opts = NULL;
+			}
+			free(tcp_context->ip_contexts[i]);
+			tcp_context->ip_contexts[i] = NULL;
+		}
+	}
 	free(tcp_context);
 
 	/* free the volatile part of the decompression context */
-    struct rohc_tcp_decoded_values *decoded = (struct rohc_tcp_decoded_values *)volat_ctxt->decoded_values;
-    struct rohc_tcp_extr_bits *extrab = (struct rohc_tcp_extr_bits *)volat_ctxt->extr_bits;
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        if(decoded->ip[i].opts != NULL) 
-        {
-            free(decoded->ip[i].opts);
-            decoded->ip[i].opts = NULL;
-        }
-        if(extrab->ip[i].opts != NULL) 
-        {
-            free(extrab->ip[i].opts);
-            extrab->ip[i].opts = NULL;
-        }
-    }
+	struct rohc_tcp_decoded_values *decoded = (struct rohc_tcp_decoded_values *)volat_ctxt->decoded_values;
+	struct rohc_tcp_extr_bits *extrab = (struct rohc_tcp_extr_bits *)volat_ctxt->extr_bits;
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		if(decoded->ip[i].opts != NULL) 
+		{
+			free(decoded->ip[i].opts);
+			decoded->ip[i].opts = NULL;
+		}
+		if(extrab->ip[i].opts != NULL) 
+		{
+			free(extrab->ip[i].opts);
+			extrab->ip[i].opts = NULL;
+		}
+	}
 	free(volat_ctxt->decoded_values);
 	free(volat_ctxt->extr_bits);
 }
@@ -2525,16 +2525,16 @@ static void d_tcp_reset_extr_bits(const struct rohc_decomp_ctxt *const context,
 	size_t i;
 
 	/* set every bits and sizes to 0 */
-    ip_option_context_t *optptrs[ROHC_TCP_MAX_IP_HDRS];
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        optptrs[i] = bits->ip[i].opts;
-    }
+	ip_option_context_t *optptrs[ROHC_TCP_MAX_IP_HDRS];
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		optptrs[i] = bits->ip[i].opts;
+	}
 	memset(bits, 0, sizeof(struct rohc_tcp_extr_bits));
-    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
-    {
-        bits->ip[i].opts = optptrs[i];
-    }
+	for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+	{
+		bits->ip[i].opts = optptrs[i];
+	}
 
 	/* if context handled at least one packet, init the list of IP headers */
 	if(context->num_recv_packets >= 1)
@@ -2550,11 +2550,11 @@ static void d_tcp_reset_extr_bits(const struct rohc_decomp_ctxt *const context,
 
 				bits->ip[i].opts_nr = tcp_context->ip_contexts[i]->opts_nr;
 				bits->ip[i].opts_len = tcp_context->ip_contexts[i]->opts_len;
-                if(bits->ip[i].opts_nr > 0 && bits->ip[i].opts == NULL)
-                {
-                    bits->ip[i].opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
-                    
-                }
+				if(bits->ip[i].opts_nr > 0 && bits->ip[i].opts == NULL)
+				{
+					bits->ip[i].opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+					
+				}
 				for(j = 0; j < bits->ip[i].opts_nr; j++)
 				{
 					bits->ip[i].opts[j].len = tcp_context->ip_contexts[i]->opts[j].len;
@@ -2953,10 +2953,10 @@ static bool d_tcp_decode_bits_ip_hdr(const struct rohc_decomp_ctxt *const contex
 	if(ip_bits->version == IPV6)
 	{
 		size_t ext_pos;
-        if(ip_decoded->opts_nr > 0 && ip_decoded->opts == NULL)
-        {
-            ip_decoded->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
-        }
+		if(ip_decoded->opts_nr > 0 && ip_decoded->opts == NULL)
+		{
+			ip_decoded->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+		}
 		for(ext_pos = 0; ext_pos < ip_decoded->opts_nr; ext_pos++)
 		{
 			switch(ip_bits->opts[ext_pos].proto)
@@ -4200,11 +4200,11 @@ static void d_tcp_update_ctxt(struct rohc_decomp_ctxt *const context,
 	{
 		const struct rohc_tcp_decoded_ip_values *const ip_decoded =
 			&(decoded->ip[ip_hdr_nr]);
-        if(tcp_context->ip_contexts[ip_hdr_nr] == NULL)
-        {
-            tcp_context->ip_contexts[ip_hdr_nr] = malloc(sizeof(ip_context_t));
-            tcp_context->ip_contexts[ip_hdr_nr]->opts = NULL;
-        }
+		if(tcp_context->ip_contexts[ip_hdr_nr] == NULL)
+		{
+			tcp_context->ip_contexts[ip_hdr_nr] = malloc(sizeof(ip_context_t));
+			tcp_context->ip_contexts[ip_hdr_nr]->opts = NULL;
+		}
 		ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_nr];
 		const bool is_inner = !!(ip_hdr_nr == (decoded->ip_nr - 1));
 
@@ -4273,10 +4273,10 @@ static void d_tcp_update_ctxt(struct rohc_decomp_ctxt *const context,
 			/* remember the extension headers */
 			ip_context->opts_nr = ip_decoded->opts_nr;
 			ip_context->opts_len = ip_decoded->opts_len;
-            if(ip_context->opts == NULL)
-            {
-                ip_context->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
-            }
+			if(ip_context->opts == NULL)
+			{
+				ip_context->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+			}
 			for(ext_pos = 0; ext_pos < ip_context->opts_nr; ext_pos++)
 			{
 				const size_t ext_len = ip_decoded->opts[ext_pos].len;

--- a/src/decomp/d_tcp.c
+++ b/src/decomp/d_tcp.c
@@ -54,7 +54,6 @@
 #endif
 #include <stdint.h>
 
-
 /*
  * Private function prototypes.
  */
@@ -503,6 +502,13 @@ static bool d_tcp_create(const struct rohc_decomp_ctxt *const context,
 		                 "of one of the TCP decompression context");
 		goto free_extr_bits;
 	}
+    
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        tcp_context->ip_contexts[i] = NULL;
+        ((struct rohc_tcp_extr_bits*)(volat_ctxt->extr_bits))->ip[i].opts = NULL;
+        ((struct rohc_tcp_decoded_values*)(volat_ctxt->decoded_values))->ip[i].opts = NULL;
+    }
 
 	return true;
 
@@ -571,9 +577,37 @@ static void d_tcp_destroy(struct d_tcp_context *const tcp_context,
 	rohc_lsb_free(tcp_context->msn_lsb_ctxt);
 
 	/* free the TCP decompression context itself */
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        if(tcp_context->ip_contexts[i] != NULL) 
+        {
+            if(tcp_context->ip_contexts[i]->opts != NULL) 
+            {
+                free(tcp_context->ip_contexts[i]->opts);
+                tcp_context->ip_contexts[i]->opts = NULL;
+            }
+            free(tcp_context->ip_contexts[i]);
+            tcp_context->ip_contexts[i] = NULL;
+        }
+    }
 	free(tcp_context);
 
 	/* free the volatile part of the decompression context */
+    struct rohc_tcp_decoded_values *decoded = (struct rohc_tcp_decoded_values *)volat_ctxt->decoded_values;
+    struct rohc_tcp_extr_bits *extrab = (struct rohc_tcp_extr_bits *)volat_ctxt->extr_bits;
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        if(decoded->ip[i].opts != NULL) 
+        {
+            free(decoded->ip[i].opts);
+            decoded->ip[i].opts = NULL;
+        }
+        if(extrab->ip[i].opts != NULL) 
+        {
+            free(extrab->ip[i].opts);
+            extrab->ip[i].opts = NULL;
+        }
+    }
 	free(volat_ctxt->decoded_values);
 	free(volat_ctxt->extr_bits);
 }
@@ -633,7 +667,7 @@ static rohc_packet_t tcp_detect_packet_type(const struct rohc_decomp_ctxt *const
 			}
 			assert(tcp_context->ip_contexts_nr > 0);
 			innermost_hdr_ctxt =
-				&(tcp_context->ip_contexts[tcp_context->ip_contexts_nr - 1]);
+				tcp_context->ip_contexts[tcp_context->ip_contexts_nr - 1];
 			innermost_ip_id_behavior = innermost_hdr_ctxt->ctxt.vx.ip_id_behavior;
 			is_ip_id_seq = (innermost_ip_id_behavior <= IP_ID_BEHAVIOR_SEQ_SWAP);
 			rohc_decomp_debug(context, "IPv%u header #%zu is the innermost IP header",
@@ -1030,7 +1064,7 @@ static bool d_tcp_parse_CO(const struct rohc_decomp_ctxt *const context,
 	                  large_cid_len, rohc_length);
 
 	assert(tcp_context->ip_contexts_nr > 0);
-	ip_inner_context = &(tcp_context->ip_contexts[tcp_context->ip_contexts_nr - 1]);
+	ip_inner_context = tcp_context->ip_contexts[tcp_context->ip_contexts_nr - 1];
 	assert(bits->ip_nr > 0);
 	inner_ip_bits = &(bits->ip[bits->ip_nr - 1]);
 
@@ -2245,7 +2279,7 @@ static bool d_tcp_parse_co_common(const struct rohc_decomp_ctxt *const context,
 {
 	const struct d_tcp_context *const tcp_context = context->persist_ctxt;
 	const ip_context_t *const innermost_ip_ctxt =
-		&(tcp_context->ip_contexts[tcp_context->ip_contexts_nr - 1]);
+		tcp_context->ip_contexts[tcp_context->ip_contexts_nr - 1];
 	struct rohc_tcp_extr_ip_bits *const innermost_ip_bits =
 		&(bits->ip[bits->ip_nr - 1]);
 
@@ -2491,28 +2525,42 @@ static void d_tcp_reset_extr_bits(const struct rohc_decomp_ctxt *const context,
 	size_t i;
 
 	/* set every bits and sizes to 0 */
+    ip_option_context_t *optptrs[ROHC_TCP_MAX_IP_HDRS];
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        optptrs[i] = bits->ip[i].opts;
+    }
 	memset(bits, 0, sizeof(struct rohc_tcp_extr_bits));
+    for(unsigned int i = 0; i < ROHC_TCP_MAX_IP_HDRS; i++) 
+    {
+        bits->ip[i].opts = optptrs[i];
+    }
 
 	/* if context handled at least one packet, init the list of IP headers */
 	if(context->num_recv_packets >= 1)
 	{
 		for(i = 0; i < tcp_context->ip_contexts_nr; i++)
 		{
-			bits->ip[i].version = tcp_context->ip_contexts[i].version;
-			bits->ip[i].proto = tcp_context->ip_contexts[i].ctxt.vx.next_header;
+			bits->ip[i].version = tcp_context->ip_contexts[i]->version;
+			bits->ip[i].proto = tcp_context->ip_contexts[i]->ctxt.vx.next_header;
 			bits->ip[i].proto_nr = 8;
 			if(bits->ip[i].version == IPV6)
 			{
 				size_t j;
 
-				bits->ip[i].opts_nr = tcp_context->ip_contexts[i].opts_nr;
-				bits->ip[i].opts_len = tcp_context->ip_contexts[i].opts_len;
+				bits->ip[i].opts_nr = tcp_context->ip_contexts[i]->opts_nr;
+				bits->ip[i].opts_len = tcp_context->ip_contexts[i]->opts_len;
+                if(bits->ip[i].opts_nr > 0 && bits->ip[i].opts == NULL)
+                {
+                    bits->ip[i].opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+                    
+                }
 				for(j = 0; j < bits->ip[i].opts_nr; j++)
 				{
-					bits->ip[i].opts[j].len = tcp_context->ip_contexts[i].opts[j].len;
-					bits->ip[i].opts[j].proto = tcp_context->ip_contexts[i].opts[j].proto;
+					bits->ip[i].opts[j].len = tcp_context->ip_contexts[i]->opts[j].len;
+					bits->ip[i].opts[j].proto = tcp_context->ip_contexts[i]->opts[j].proto;
 					bits->ip[i].opts[j].nh_proto =
-						tcp_context->ip_contexts[i].opts[j].nh_proto;
+						tcp_context->ip_contexts[i]->opts[j].nh_proto;
 				}
 			}
 		}
@@ -2632,7 +2680,7 @@ static bool d_tcp_decode_bits_ip_hdrs(const struct rohc_decomp_ctxt *const conte
 	for(ip_hdr_nr = 0; ip_hdr_nr < bits->ip_nr; ip_hdr_nr++)
 	{
 		const struct rohc_tcp_extr_ip_bits *const ip_bits = &(bits->ip[ip_hdr_nr]);
-		const ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_nr]);
+		const ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_nr];
 		struct rohc_tcp_decoded_ip_values *const ip_decoded = &(decoded->ip[ip_hdr_nr]);
 
 		rohc_decomp_debug(context, "decode fields of IP header #%zu", ip_hdr_nr + 1);
@@ -2905,7 +2953,10 @@ static bool d_tcp_decode_bits_ip_hdr(const struct rohc_decomp_ctxt *const contex
 	if(ip_bits->version == IPV6)
 	{
 		size_t ext_pos;
-
+        if(ip_decoded->opts_nr > 0 && ip_decoded->opts == NULL)
+        {
+            ip_decoded->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+        }
 		for(ext_pos = 0; ext_pos < ip_decoded->opts_nr; ext_pos++)
 		{
 			switch(ip_bits->opts[ext_pos].proto)
@@ -4149,7 +4200,12 @@ static void d_tcp_update_ctxt(struct rohc_decomp_ctxt *const context,
 	{
 		const struct rohc_tcp_decoded_ip_values *const ip_decoded =
 			&(decoded->ip[ip_hdr_nr]);
-		ip_context_t *const ip_context = &(tcp_context->ip_contexts[ip_hdr_nr]);
+        if(tcp_context->ip_contexts[ip_hdr_nr] == NULL)
+        {
+            tcp_context->ip_contexts[ip_hdr_nr] = malloc(sizeof(ip_context_t));
+            tcp_context->ip_contexts[ip_hdr_nr]->opts = NULL;
+        }
+		ip_context_t *const ip_context = tcp_context->ip_contexts[ip_hdr_nr];
 		const bool is_inner = !!(ip_hdr_nr == (decoded->ip_nr - 1));
 
 		rohc_decomp_debug(context, "update context for IPv%u header #%zu",
@@ -4217,6 +4273,10 @@ static void d_tcp_update_ctxt(struct rohc_decomp_ctxt *const context,
 			/* remember the extension headers */
 			ip_context->opts_nr = ip_decoded->opts_nr;
 			ip_context->opts_len = ip_decoded->opts_len;
+            if(ip_context->opts == NULL)
+            {
+                ip_context->opts = malloc(ROHC_TCP_MAX_IP_EXT_HDRS*sizeof(ip_option_context_t));
+            }
 			for(ext_pos = 0; ext_pos < ip_context->opts_nr; ext_pos++)
 			{
 				const size_t ext_len = ip_decoded->opts[ext_pos].len;
@@ -4367,4 +4427,3 @@ const struct rohc_decomp_profile d_tcp_profile =
 	.attempt_repair  = (rohc_decomp_attempt_repair_t) d_tcp_attempt_repair,
 	.get_sn          = d_tcp_get_msn
 };
-

--- a/src/decomp/d_tcp_defines.h
+++ b/src/decomp/d_tcp_defines.h
@@ -194,7 +194,7 @@ typedef struct
 
 	size_t opts_nr;
 	size_t opts_len;
-	ip_option_context_t opts[ROHC_TCP_MAX_IP_EXT_HDRS];
+	ip_option_context_t *opts;
 
 } ip_context_t;
 
@@ -312,7 +312,7 @@ struct d_tcp_context
 	struct d_tcp_opt_sack opt_sack_blocks;  /**< The TCP SACK blocks */
 
 	size_t ip_contexts_nr;
-	ip_context_t ip_contexts[ROHC_TCP_MAX_IP_HDRS];
+	ip_context_t *ip_contexts[ROHC_TCP_MAX_IP_HDRS];
 };
 
 
@@ -352,7 +352,7 @@ struct rohc_tcp_extr_ip_bits
 	size_t daddr_nr;     /**< The number of source address bits */
 
 	/** The parsed IP extension headers */
-	ip_option_context_t opts[ROHC_TCP_MAX_IP_EXT_HDRS];
+	ip_option_context_t *opts;
 	size_t opts_nr;  /**< The number of parsed IP extension headers */
 	size_t opts_len; /**< The length of the parsed IP extension headers */
 };
@@ -427,7 +427,7 @@ struct rohc_tcp_decoded_ip_values
 	uint8_t daddr[16];   /**< The decoded destination address field */
 
 	/** The decoded IP extension headers */
-	ip_option_context_t opts[ROHC_TCP_MAX_IP_EXT_HDRS];
+	ip_option_context_t *opts;
 	size_t opts_nr;  /**< The number of decoded IP extension headers */
 	size_t opts_len; /**< The length of the decoded IP extension headers */
 };
@@ -485,4 +485,3 @@ struct rohc_tcp_decoded_values
 };
 
 #endif /* ROHC_DECOMP_TCP_DEFINES_H */
-

--- a/src/decomp/d_tcp_irregular.c
+++ b/src/decomp/d_tcp_irregular.c
@@ -113,7 +113,7 @@ bool tcp_parse_irreg_chain(const struct rohc_decomp_ctxt *const context,
 	    ip_contexts_nr++)
 	{
 		const ip_context_t *const ip_context =
-			&(tcp_context->ip_contexts[ip_contexts_nr]);
+			tcp_context->ip_contexts[ip_contexts_nr];
 		struct rohc_tcp_extr_ip_bits *const ip_bits = &(bits->ip[ip_contexts_nr]);
 		const bool is_inner_ip =
 			(ip_contexts_nr == (tcp_context->ip_contexts_nr - 1));
@@ -516,4 +516,3 @@ static inline bool d_tcp_is_ecn_used(const struct d_tcp_context *const tcp_ctxt,
 {
 	return ((bits->ecn_used_bits_nr > 0) ? (!!bits->ecn_used_bits) : tcp_ctxt->ecn_used);
 }
-

--- a/src/decomp/rohc_decomp_rfc3095.c
+++ b/src/decomp/rohc_decomp_rfc3095.c
@@ -48,7 +48,6 @@
 #endif
 #include <assert.h>
 
-
 /*
  * Private function prototypes for parsing the static and dynamic parts
  * of the IR and IR-DYN headers
@@ -6352,4 +6351,3 @@ static void reset_extr_bits(const struct rohc_decomp_rfc3095_ctxt *const rfc3095
 	 */
 	bits->is_ts_scaled = true;
 }
-

--- a/src/decomp/schemes/decomp_list_ipv6.c
+++ b/src/decomp/schemes/decomp_list_ipv6.c
@@ -95,6 +95,12 @@ void rohc_decomp_list_ipv6_new(struct list_decomp *const decomp,
  */
 void rohc_decomp_list_ipv6_free(struct list_decomp *const decomp)
 {
+    for(unsigned int i = 0; i < ROHC_LIST_MAX_ITEM; i++) {
+        if(decomp->trans_table[i].data != NULL) {
+            free(decomp->trans_table[i].data);
+            decomp->trans_table[i].data = NULL;
+        }
+    }
 	memset(decomp, 0, sizeof(struct list_decomp));
 }
 
@@ -274,4 +280,3 @@ static size_t rohc_build_ip6_extension(const struct list_decomp *const decomp,
 
 	return size;
 }
-

--- a/src/decomp/schemes/decomp_list_ipv6.c
+++ b/src/decomp/schemes/decomp_list_ipv6.c
@@ -95,8 +95,10 @@ void rohc_decomp_list_ipv6_new(struct list_decomp *const decomp,
  */
 void rohc_decomp_list_ipv6_free(struct list_decomp *const decomp)
 {
-	for(unsigned int i = 0; i < ROHC_LIST_MAX_ITEM; i++) {
-		if(decomp->trans_table[i].data != NULL) {
+	for(unsigned int i = 0; i < ROHC_LIST_MAX_ITEM; i++)
+	{
+		if(decomp->trans_table[i].data != NULL)
+		{
 			free(decomp->trans_table[i].data);
 			decomp->trans_table[i].data = NULL;
 		}

--- a/src/decomp/schemes/decomp_list_ipv6.c
+++ b/src/decomp/schemes/decomp_list_ipv6.c
@@ -95,12 +95,12 @@ void rohc_decomp_list_ipv6_new(struct list_decomp *const decomp,
  */
 void rohc_decomp_list_ipv6_free(struct list_decomp *const decomp)
 {
-    for(unsigned int i = 0; i < ROHC_LIST_MAX_ITEM; i++) {
-        if(decomp->trans_table[i].data != NULL) {
-            free(decomp->trans_table[i].data);
-            decomp->trans_table[i].data = NULL;
-        }
-    }
+	for(unsigned int i = 0; i < ROHC_LIST_MAX_ITEM; i++) {
+		if(decomp->trans_table[i].data != NULL) {
+			free(decomp->trans_table[i].data);
+			decomp->trans_table[i].data = NULL;
+		}
+	}
 	memset(decomp, 0, sizeof(struct list_decomp));
 }
 


### PR DESCRIPTION
Dynamically allocate some context elements only when they are needed. Significantly reduces memory usage for IPv4 streams.